### PR TITLE
bugfix: replace docker copy path from /usr/src/app to . which means t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY package*.json /usr/src/app
+COPY package*.json .
 RUN npm ci
-COPY . /usr/src/app
+COPY . .
 CMD [ "npm","run","start"]


### PR DESCRIPTION
…he current directory that docker on and since we used WORKDIR /usr/src/app no need to write the path in COPY as it means new subdirectory. 

Fixes #1 